### PR TITLE
Friendly fire hitsound bug fix, Water slowdown on edit mode fix, Shotgun and sniper balance edits

### DIFF
--- a/src/engine/physics.cpp
+++ b/src/engine/physics.cpp
@@ -1765,7 +1765,7 @@ bool moveplayer(physent *pl, int moveres, bool local, int curtime)
     modifyvelocity(pl, local, water, floating, curtime);
 
     vec d(pl->vel);
-    if((!floating || !ispack) && water) d.mul(0.5f);
+    if((!floating || !ispack) && water && !editmode) d.mul(0.5f);
     d.add(pl->falling);
     d.mul(secs);
 

--- a/src/fpsgame/game.h
+++ b/src/fpsgame/game.h
@@ -359,8 +359,8 @@ static struct guninfo { int sound, attackdelay, damage, spread, projspeed, kicka
 {
     { S_PUNCH1,     10,  400,   0,   0,  0,   14,  1,  80,  0,    0, "fist",            "fist",   0, false, 10 },
     { S_ARIFLE,    150,  200,  50,   0, 12, 1024,  1,  80,  0,    0, "smg",             "smg",    0, false, 10 },
-    { S_SG,       1400,   80, 400,   0, 20, 1024, 20,  80,  0,    0, "shotgun",         "shotg",  0, true, 10 },
-    { S_RIFLE,    1500,  900,   0,   0, 30, 2048,  1,  80,  0,    0, "rifle",           "rifle",  0, false, 10 },
+    { S_SG,       1360,   80, 320,   0, 20, 1024, 20,  80,  0,    0, "shotgun",         "shotg",  0, true, 10 },
+    { S_RIFLE,    1400,  900,   0,   0, 30, 2048,  1,  80,  0,    0, "rifle",           "rifle",  0, false, 10 },
     { S_CG,        100,  150, 100,   0, 10, 1024,  1,  80,  0,    0, "chaingun",        "chaing", 0, true, 10 },
     { S_RLFIRE,    800, 1200,   0, 320, 10, 1024,  1, 160, 40,    0, "rocketlauncher",  "rocket", 0, true, 10 },
     { S_FLAUNCH,  1000,  900,   0, 200, 10, 1024,  1, 250, 45, 1500, "grenadelauncher", "gl",     0, true, 10 },

--- a/src/fpsgame/weapon.cpp
+++ b/src/fpsgame/weapon.cpp
@@ -387,7 +387,9 @@ namespace game
 
     void hit(int damage, dynent *d, fpsent *at, const vec &vel, int gun, float info1, int info2 = 1)
     {
-        if(at==player1 && d!=at)
+		fpsent *f = (fpsent *)d;
+
+        if(at==player1 && d!=at && !isteam(at->team, f->team))
         {
             extern int hitsound;
             if(hitsound && lasthit != lastmillis && !m_parkour) playsound(S_HIT);
@@ -400,8 +402,7 @@ namespace game
             return;
         }
 
-        fpsent *f = (fpsent *)d;
-
+        
         f->lastpain = lastmillis;
         if(at->type==ENT_PLAYER && !isteam(at->team, f->team)) at->totaldamage += damage;
 


### PR DESCRIPTION
default shotgun spread was wayy too op for insta tac so i reduced it. and i think that its ROF and also the snipers should be faster.

Water should not slow you down anymore in edit mode and hitsounds dont play on friendly fire anymore.